### PR TITLE
[JBWS-4156] Get rid of duplicated plugin execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
           <execution>
             <id>attach-sources</id>
             <goals>
-              <goal>jar</goal>
+              <goal>jar-no-fork</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4156

This is part of the solution for the issue, making maven-source-plugin execute within main execution thread and as such not to duplicate some plugins' executions. This is also the recommended usage of the plugin as per http://maven.apache.org/plugins/maven-source-plugin/usage.html