### PR TITLE
[JBWS-4475] - Downgrade maven-compiler-plugin to 3.5.1 to allow building jbossws-cxf (>5.4.17) with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,11 @@
     <modular.jdk.args />
     <modular.jdk.props />
     <!-- maven-compiler-plugin -->
+    <!-- Don't use release properties - source/target only for JDK 8 compatibility -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
     <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
-    <maven.compiler.release>8</maven.compiler.release>
-    <maven.compiler.testRelease>8</maven.compiler.testRelease>
     <!-- maven-enforcer-plugin -->
     <maven.min.version>3.2.5</maven.min.version>
     <jdk.min.version>${maven.compiler.source}</jdk.min.version>
@@ -216,7 +215,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <!-- Use 3.5.1 which doesn't support release flag, for JDK 8 compatibility -->
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Will be consumed by jbossws-cxf 5.4.x, for its artifacts to be deployed to Nexus 3, see https://redhat.atlassian.net/browse/JBWS-4475